### PR TITLE
Fix not consumables and parallel

### DIFF
--- a/src/main/java/gregicadditions/capabilities/impl/GAMultiblockRecipeLogic.java
+++ b/src/main/java/gregicadditions/capabilities/impl/GAMultiblockRecipeLogic.java
@@ -8,7 +8,6 @@ import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.multiblock.MultiblockAbility;
 import gregtech.api.metatileentity.multiblock.RecipeMapMultiblockController;
 import gregtech.api.recipes.Recipe;
-import gregtech.api.util.GTUtility;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.items.IItemHandler;

--- a/src/main/java/gregicadditions/machines/multi/simple/LargeSimpleRecipeMapMultiblockController.java
+++ b/src/main/java/gregicadditions/machines/multi/simple/LargeSimpleRecipeMapMultiblockController.java
@@ -406,11 +406,12 @@ abstract public class LargeSimpleRecipeMapMultiblockController extends GARecipeM
             for (int slot = 0; slot < inputs.getSlots(); slot++) {
                 ItemStack wholeItemStack = inputs.getStackInSlot(slot);
                 // skip empty slots
-                if (wholeItemStack.isEmpty())
+                String name = wholeItemStack.getItem().getUnlocalizedNameInefficiently(wholeItemStack);
+                if (name.equals("tile.air"))
                     continue;
                 boolean found = false;
                 for (ItemStack i : countIngredients) {
-                    if (wholeItemStack.isItemEqual(wholeItemStack)) {
+                    if (i.isItemEqual(wholeItemStack)) {
                         i.setCount(i.getCount() + wholeItemStack.getCount());
                         found = true;
                         break;


### PR DESCRIPTION
If a not consumable was first in the input list, multiblocks would force max parallel. Fixes this.

Minecraft is really really dumb.